### PR TITLE
Fix CounterApp and testing not working

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
-var App = artifacts.require('./App.sol')
+var CounterApp = artifacts.require('CounterApp.sol')
 
 module.exports = function (deployer) {
-  deployer.deploy(App)
+  deployer.deploy(CounterApp)
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
-    "parcel-bundler": "^1.8.1",
+    "parcel-bundler": "^1.9.3",
     "truffle": "4.0.5"
   },
   "scripts": {
@@ -27,7 +27,7 @@
     "compile": "aragon contracts compile",
     "sync-assets": "mkdir -p dist; rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" dist/aragon-ui",
     "build:app": "parcel build app/index.html -d dist/ --public-url '.'",
-    "build:script": "exit 0 && parcel build app/script.js -d dist/",
+    "build:script": "parcel build app/script.js -d dist/",
     "build": "npm run sync-assets && npm run build:app && npm run build:script",
     "publish": "aragon publish"
   },

--- a/test/app.js
+++ b/test/app.js
@@ -1,4 +1,4 @@
-const CounterApp = artifacts.require('./CounterApp.sol')
+const CounterApp = artifacts.require('CounterApp.sol')
 
 contract('CounterApp', (accounts) => {
   it('should be tested')


### PR DESCRIPTION
- Closes #4: The test problem was produced by a bad import naming causing test script unable to find the contract.
- Closes #5: The CounterApp malfunction was caused by an old parcel version not producing the right dist/script.js so the app couldn't communicate with the smart contract.
